### PR TITLE
Add environment variable placeholders

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,12 @@
+# Environment configuration for the Django backend
+# Copy this template to `.env` and update the values for local development
 
+DJANGO_SECRET_KEY=changeme
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+
+# Email settings
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_HOST_USER=your_email@example.com
+EMAIL_HOST_PASSWORD=your_password
+EMAIL_USE_TLS=True


### PR DESCRIPTION
## Summary
- provide example `.env` variables for backend setup
- instruct developers to copy `.env.example` to `.env`

## Testing
- `cat backend/.env.example`

------
https://chatgpt.com/codex/tasks/task_e_6845b2e4150c832fa5b4f140b077262b