### PR TITLE
Fix corrupted line in internships urls

### DIFF
--- a/backend/apps/internships/urls.py
+++ b/backend/apps/internships/urls.py
@@ -5,4 +5,3 @@ router = DefaultRouter()
 router.register(r'', InternshipViewSet)
 
 urlpatterns = router.urls
-�{


### PR DESCRIPTION
## Summary
- remove stray characters from `backend/apps/internships/urls.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845b8cbc194832fb5811d4cf04016e4